### PR TITLE
fix: update download link path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ The specification is described in a separate [EVA / Spec](https://github.com/EVA
 
 The whole package can be downloaded as a ZIP package, otherwise you can navigate to the the specific drive or addon page and download files from there.
 
-[Download :octicons-download-24:](https://github.com/EVA-3D/eva-main/blob/main/docs/stls.zip?raw=true){: .md-button .md-button--primary }
+[Download :octicons-download-24:](https://github.com/EVA-3D/eva-main/blob/main/stls.zip?raw=true){: .md-button .md-button--primary }
 
 ## Support
 


### PR DESCRIPTION
responds to the change that was made in 81958ae

I was trying to download but got a 404, so here's a quick fix!
I didn't build the docs, but it works when inputting the URL (https://github.com/EVA-3D/eva-main/blob/main/stls.zip?raw=true).

let me know if anything else needs to be done!

cheers,
~S